### PR TITLE
Remove trailing comma

### DIFF
--- a/node/package.json
+++ b/node/package.json
@@ -6,6 +6,6 @@
   "license": "MIT",
   "dependencies": {
     "google-protobuf": "^3.2.0",
-    "grpc": "^1.2.0",
+    "grpc": "^1.2.0"
   }
 }


### PR DESCRIPTION
That trailing comma was causing you can't install the dependencies.